### PR TITLE
Support schema package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,17 +8,163 @@ var merge = function(a, b) {
   return a
 }
 
+function mergeSchemas(schemas) {
+  var sch = schemas.reduce(merge)
+  delete sch.package
+  delete sch.imports
+  return sch
+}
+
+function collectMessages(schema, ns, f) {
+  schema.messages.forEach(function(msg) {
+    var fullName = msg.fullName || (ns ? [ns, msg.name].join('.') : msg.name)
+    f(msg, fullName)
+    collectMessages(msg, fullName, f)
+  })
+  var extends_ = schema.extends || []
+  extends_.forEach(function(ext) {
+    f(ext.message, ns)
+  })
+}
+
+function collectExtends(schema, ns, f) {
+  (schema.extends || []).forEach(function(ext) {
+    f(ext, ns)
+  })
+  collectMessages(schema, ns, function(msg, ns) {
+    collectExtends(msg, ns, f)
+  })
+}
+
+function collectEnums(schema, ns, f) {
+  schema.enums.forEach(function(en) {
+    var shouldPrefix = ns && !en.name.match(/\./)
+    var fullName = shouldPrefix ? [ns, en.name].join('.') : en.name
+    f(en, fullName)
+  })
+  collectMessages(schema, ns, function(msg, ns) {
+    collectEnums(msg, ns, f)
+  })
+}
+
+function collectFields(schema, ns, f) {
+  collectMessages(schema, ns, function(message, ns) {
+    message.fields.forEach(function(field) {
+      f(field, ns)
+    })
+  })
+}
+
+function collectIntoArray(schema, collector) {
+  var values = []
+  collector(schema, schema.package, function(value) {
+    values.push(value)
+  })
+  return values
+}
+
+function qualifyFieldTypes(schema) {
+  var messages = collectIntoArray(schema, collectMessages)
+  var enums = collectIntoArray(schema, collectEnums)
+  var types = messages.concat(enums)
+  collectFields(schema, schema.package, function(field, ns) {
+    var type = field.type
+    var refCandidates = getCandidates(ns, type)
+    refCandidates.some(function(refCandidate) {
+      return types.some(function(type) {
+        if (type.fullName === refCandidate) {
+          field.type = refCandidate
+          return true
+        }
+        return false
+      })
+    })
+  })
+}
+
+function qualifyMessages(schema) {
+  collectMessages(schema, schema.package, function(msg, fullName) {
+    msg.fullName = fullName
+  })
+  collectEnums(schema, schema.package, function(en, fullName) {
+    en.fullName = fullName
+  })
+  schema.messages.forEach(function(msg) {
+    msg.name = msg.fullName
+  })
+  schema.enums.forEach(function(en) {
+    en.name = en.fullName
+  })
+}
+
+function getCandidates(ns, ref) {
+  var results = [ref]
+
+  var index
+  var candidatePrefix
+  while (true) {
+    index = ns.indexOf('.', index + 1)
+    if (index === -1) {
+        break
+    }
+    candidateNs = ns.slice(0, index)
+    results.unshift(candidatePrefix + '.' + ref)
+  }
+
+  results.unshift(ns + '.' + ref)
+  return results
+}
+
+function extendMessage(ext, msg) {
+  ext.message.fields.forEach(function (field) {
+    if (!msg.extensions || field.tag < msg.extensions.from || field.tag > msg.extensions.to) {
+      throw new Error(msg.name + ' does not declare ' + field.tag +
+                      ' as an extension number')
+    }
+    msg.fields.push(field)
+  })
+}
+
+function propagateExtends(schemas) {
+  schemas.reduceRight(function(messages, extSchema) {
+    var messages = collectIntoArray(extSchema, collectMessages).concat(messages)
+
+    collectExtends(extSchema, extSchema.package, function(ext, ns) {
+      var refCandidates = getCandidates(ns, ext.name)
+      var matchingMessage
+      refCandidates.some(function(refCandidate) {
+        return messages.some(function(message) {
+          if (message.fullName === refCandidate) {
+            matchingMessage = message
+            return true
+          }
+          return false
+        })
+      })
+      if (matchingMessage) {
+        extendMessage(ext, matchingMessage)
+      } else {
+        throw new Error(ext.name + ' extend references unknown message')
+      }
+    })
+
+    return messages
+  }, [])
+  return schemas
+}
+
 var readSync = function(filename) {
   if (!/\.proto$/i.test(filename) && !fs.existsSync(filename)) filename += '.proto'
 
   var sch = schema(fs.readFileSync(filename, 'utf-8'))
   var imports = [].concat(sch.imports || [])
+  var schemas = [sch]
 
   imports.forEach(function(i) {
-    sch = merge(sch, readSync(path.resolve(path.dirname(filename), i)))
+    schemas = schemas.concat(readSync(path.resolve(path.dirname(filename), i)))
   })
 
-  return sch
+  return schemas
 }
 
 var read = function(filename, cb) {
@@ -30,13 +176,14 @@ var read = function(filename, cb) {
 
       var sch = schema(proto)
       var imports = [].concat(sch.imports || [])
+      var schemas = [sch]
 
       var loop = function() {
-        if (!imports.length) return cb(null, sch)
+        if (!imports.length) return cb(null, schemas)
 
         read(path.resolve(path.dirname(filename), imports.shift()), function(err, ch) {
           if (err) return cb(err)
-          sch = merge(sch, ch)
+          schemas = schemas.concat(ch)
           loop()
         })
       }
@@ -46,5 +193,25 @@ var read = function(filename, cb) {
   })
 }
 
-module.exports = read
-module.exports.sync = readSync
+function readAndMerge(filename, cb) {
+  read(filename, function(err, schemas) {
+    if (err) return cb(err)
+    schemas.forEach(qualifyMessages)
+    schemas.forEach(qualifyFieldTypes)
+    propagateExtends(schemas)
+    var sch = mergeSchemas(schemas)
+    cb(null, sch)
+  })
+}
+
+function readAndMergeSync(filename) {
+  var schemas = readSync(filename)
+  schemas.forEach(qualifyMessages)
+  schemas.forEach(qualifyFieldTypes)
+  propagateExtends(schemas)
+  var sch = mergeSchemas(schemas)
+  return sch
+}
+
+module.exports = readAndMerge
+module.exports.sync = readAndMergeSync

--- a/test/f.proto
+++ b/test/f.proto
@@ -1,0 +1,6 @@
+package f;
+
+message F {
+  optional int32 f = 1;
+  extensions 2 to 10;
+}

--- a/test/g.json
+++ b/test/g.json
@@ -1,0 +1,164 @@
+{
+  "syntax": 3,
+  "enums": [],
+  "messages": [
+    {
+      "name": "g.G",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "f",
+          "type": "f.F",
+          "tag": 1,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        }
+      ],
+      "extensions": null,
+      "fullName": "g.G"
+    },
+    {
+      "name": "g.H",
+      "enums": [],
+      "extends": [],
+      "messages": [
+        {
+          "name": "I",
+          "enums": [],
+          "extends": [],
+          "messages": [
+            {
+              "name": "J",
+              "enums": [],
+              "extends": [],
+              "messages": [
+                {
+                  "name": "I",
+                  "enums": [],
+                  "extends": [],
+                  "messages": [],
+                  "fields": [],
+                  "extensions": null,
+                  "fullName": "g.H.I.J.I"
+                }
+              ],
+              "fields": [
+                {
+                  "name": "bar",
+                  "type": "g.G",
+                  "tag": 2,
+                  "map": null,
+                  "oneof": null,
+                  "required": false,
+                  "repeated": false,
+                  "options": {}
+                }
+              ],
+              "extensions": {
+                "from": 1,
+                "to": 10
+              },
+              "fullName": "g.H.I.J"
+            }
+          ],
+          "fields": [],
+          "extensions": null,
+          "fullName": "g.H.I"
+        }
+      ],
+      "fields": [],
+      "extensions": {
+        "from": 1,
+        "to": 10
+      },
+      "fullName": "g.H"
+    },
+    {
+      "name": "f.F",
+      "enums": [],
+      "extends": [],
+      "messages": [],
+      "fields": [
+        {
+          "name": "f",
+          "type": "int32",
+          "tag": 1,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        },
+        {
+          "name": "g",
+          "type": "g.G",
+          "tag": 2,
+          "map": null,
+          "oneof": null,
+          "required": false,
+          "repeated": false,
+          "options": {}
+        }
+      ],
+      "extensions": {
+        "from": 2,
+        "to": 10
+      },
+      "fullName": "f.F"
+    }
+  ],
+  "options": {},
+  "extends": [
+    {
+      "name": "f.F",
+      "message": {
+        "name": "f.F",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "g",
+            "type": "g.G",
+            "tag": 2,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null,
+        "fullName": "g"
+      }
+    },
+    {
+      "name": "H.I.J",
+      "message": {
+        "name": "H.I.J",
+        "enums": [],
+        "extends": [],
+        "messages": [],
+        "fields": [
+          {
+            "name": "bar",
+            "type": "g.G",
+            "tag": 2,
+            "map": null,
+            "oneof": null,
+            "required": false,
+            "repeated": false,
+            "options": {}
+          }
+        ],
+        "extensions": null,
+        "fullName": "g"
+      }
+    }
+  ]
+}

--- a/test/g.proto
+++ b/test/g.proto
@@ -1,0 +1,26 @@
+package g;
+
+import "f.proto";
+
+message G {
+  optional f.F f = 1;
+}
+
+message H {
+  extensions 1 to 10;
+  message I {
+    message J {
+      extensions 1 to 10;
+      message I {
+      }
+    }
+  }
+}
+
+extend f.F {
+  optional G g = 2;
+}
+
+extend H.I.J {
+  optional G bar = 2;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -47,3 +47,15 @@ test('a imports b imports c', function(t, schema) {
     })
   })
 })
+
+test('G references f.F', function(t, schema) {
+  schema(__dirname+'/g.proto', function(err, sch) {
+    t.notOk(err, 'no err')
+    t.same(sch, require('./g.json'))
+    schema(__dirname+'/g', function(err, sch) {
+      t.notOk(err, 'no err')
+      t.same(sch.messages.length, 3)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
- Fully qualify message and enum names in schemas which have a package
  directive.
- Resolve field type references to qualified message or enum name.
- Allow referencing types which are nonlocal to the field's package.
- Allow extending messages which are nonlocal to the extend's package.
